### PR TITLE
Add initial Vite React TypeScript app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
-# exegesis_app
-UI for the exegesis repository
+# Exegesis App
+
+This project provides a simple Vite + React frontend written in TypeScript using the SWC compiler. The goal is to give non‑technical users a way to submit articles and offer reviews for the `theonize/exegesis` repository.
+
+## Development
+
+1. Install dependencies (requires node and npm or yarn):
+   ```bash
+   npm install
+   # or
+   yarn install
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```
+
+The application currently contains placeholder text and a TODO for implementing GitHub authentication and repo interactions (commits and pull requests).

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Exegesis Submission App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "exegesis_app",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "exegesis_app",
+  "version": "1.0.0",
+  "description": "UI for the exegesis repository",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0",
+    "typescript": "^5.3.3",
+    "@vitejs/plugin-react-swc": "^3.5.0"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,18 @@
+import { useState } from 'react';
+
+export default function App() {
+  const [message] = useState('Welcome to Exegesis Submission App');
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>{message}</h1>
+      <p>
+        This app allows non-technical users to submit new papers, review
+        existing content, and create pull requests against the
+        <code>theonize/exegesis</code> repository.
+      </p>
+      <p>
+        TODO: Implement GitHub authentication and interactions with the repo.
+      </p>
+    </div>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react-swc';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- set up a Vite + React + SWC skeleton using TypeScript
- add basic placeholder React app
- document how to install dependencies and run the dev server

## Testing
- `npm run test` *(fails: Missing script)*