### PR TITLE
Add basic GitHub interaction UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,7 @@ This project provides a simple Vite + React frontend written in TypeScript using
    npm run dev
    ```
 
-The application currently contains placeholder text and a TODO for implementing GitHub authentication and repo interactions (commits and pull requests).
+The application now includes minimal GitHub integration. Users provide a
+personal access token to authenticate, search for documents in the
+`theorize/exegesis` repository, view their contents and submit or edit
+markdown files via automatically generated pull requests.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,19 @@
 import { useState } from 'react';
+import { GitHubProvider } from './GitHubContext';
+import Login from './components/Login';
+import RepoSearch from './components/RepoSearch';
+import SubmitPR from './components/SubmitPR';
 
 export default function App() {
   const [message] = useState('Welcome to Exegesis Submission App');
   return (
-    <div style={{ padding: '2rem' }}>
-      <h1>{message}</h1>
-      <p>
-        This app allows non-technical users to submit new papers, review
-        existing content, and create pull requests against the
-        <code>theonize/exegesis</code> repository.
-      </p>
-      <p>
-        TODO: Implement GitHub authentication and interactions with the repo.
-      </p>
-    </div>
+    <GitHubProvider>
+      <div style={{ padding: '2rem' }}>
+        <h1>{message}</h1>
+        <Login />
+        <RepoSearch />
+        <SubmitPR />
+      </div>
+    </GitHubProvider>
   );
 }

--- a/src/GitHubContext.tsx
+++ b/src/GitHubContext.tsx
@@ -1,0 +1,23 @@
+import React, { createContext, useContext, useState } from 'react';
+
+interface GitHubContextState {
+  token: string | null;
+  setToken: (token: string | null) => void;
+}
+
+const GitHubContext = createContext<GitHubContextState | undefined>(undefined);
+
+export function GitHubProvider({ children }: { children: React.ReactNode }) {
+  const [token, setToken] = useState<string | null>(null);
+  return (
+    <GitHubContext.Provider value={{ token, setToken }}>
+      {children}
+    </GitHubContext.Provider>
+  );
+}
+
+export function useGitHub() {
+  const ctx = useContext(GitHubContext);
+  if (!ctx) throw new Error('useGitHub must be used inside GitHubProvider');
+  return ctx;
+}

--- a/src/components/DocumentViewer.tsx
+++ b/src/components/DocumentViewer.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+import { useGitHub } from '../GitHubContext';
+import { fetchFileContent, submitDocumentPR } from '../githubApi';
+
+export default function DocumentViewer({ path }: { path: string }) {
+  const { token } = useGitHub();
+  const [content, setContent] = useState('');
+  const [editing, setEditing] = useState(false);
+  const [editText, setEditText] = useState('');
+
+  useEffect(() => {
+    async function load() {
+      if (!token) return;
+      const c = await fetchFileContent(path, token);
+      setContent(c);
+      setEditText(c);
+    }
+    load();
+  }, [path, token]);
+
+  async function submitEdit() {
+    if (!token) return;
+    await submitDocumentPR(path, editText, token);
+    setEditing(false);
+  }
+
+  return (
+    <div style={{ border: '1px solid #ccc', padding: '1rem' }}>
+      <h3>{path}</h3>
+      {editing ? (
+        <div>
+          <textarea rows={10} cols={80} value={editText} onChange={(e) => setEditText(e.target.value)} />
+          <br />
+          <button onClick={submitEdit}>Submit Edit PR</button>
+          <button onClick={() => setEditing(false)}>Cancel</button>
+        </div>
+      ) : (
+        <div>
+          <pre>{content}</pre>
+          <button onClick={() => setEditing(true)} disabled={!token}>Edit</button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -1,0 +1,22 @@
+import { useState } from 'react';
+import { useGitHub } from '../GitHubContext';
+
+export default function Login() {
+  const { token, setToken } = useGitHub();
+  const [inputToken, setInputToken] = useState('');
+
+  if (token) return <p>Authenticated with GitHub</p>;
+
+  return (
+    <div>
+      <h2>GitHub Login</h2>
+      <p>Enter a personal access token to authenticate.</p>
+      <input
+        type="password"
+        value={inputToken}
+        onChange={(e) => setInputToken(e.target.value)}
+      />
+      <button onClick={() => setToken(inputToken)}>Login</button>
+    </div>
+  );
+}

--- a/src/components/RepoSearch.tsx
+++ b/src/components/RepoSearch.tsx
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+import { useGitHub } from '../GitHubContext';
+import { searchRepoFiles } from '../githubApi';
+import DocumentViewer from './DocumentViewer';
+
+export default function RepoSearch() {
+  const { token } = useGitHub();
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<string[]>([]);
+  const [selected, setSelected] = useState<string | null>(null);
+
+  async function handleSearch() {
+    if (!token) return;
+    const files = await searchRepoFiles(query, token);
+    setResults(files);
+  }
+
+  return (
+    <div>
+      <h2>Search Documents</h2>
+      <input value={query} onChange={(e) => setQuery(e.target.value)} />
+      <button onClick={handleSearch} disabled={!token}>Search</button>
+      <ul>
+        {results.map((path) => (
+          <li key={path}>
+            <button onClick={() => setSelected(path)}>{path}</button>
+          </li>
+        ))}
+      </ul>
+      {selected && <DocumentViewer path={selected} />}
+    </div>
+  );
+}

--- a/src/components/SubmitPR.tsx
+++ b/src/components/SubmitPR.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+import { useGitHub } from '../GitHubContext';
+import { submitDocumentPR } from '../githubApi';
+
+export default function SubmitPR() {
+  const { token } = useGitHub();
+  const [path, setPath] = useState('');
+  const [content, setContent] = useState('');
+  const [status, setStatus] = useState('');
+
+  async function handleSubmit() {
+    if (!token) return;
+    setStatus('Submitting PR...');
+    try {
+      await submitDocumentPR(path, content, token);
+      setStatus('Pull request submitted');
+    } catch (err) {
+      console.error(err);
+      setStatus('Failed to submit PR');
+    }
+  }
+
+  return (
+    <div>
+      <h2>Submit New Document</h2>
+      <input
+        placeholder="path/to/file.md"
+        value={path}
+        onChange={(e) => setPath(e.target.value)}
+      />
+      <br />
+      <textarea
+        rows={10}
+        cols={80}
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+      />
+      <br />
+      <button onClick={handleSubmit} disabled={!token}>Create Pull Request</button>
+      {status && <p>{status}</p>}
+    </div>
+  );
+}

--- a/src/githubApi.ts
+++ b/src/githubApi.ts
@@ -1,0 +1,78 @@
+const OWNER = 'theorize';
+const REPO = 'exegesis';
+const API = 'https://api.github.com';
+
+async function gh<T>(url: string, token: string, options: RequestInit = {}): Promise<T> {
+  const res = await fetch(url, {
+    ...options,
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `token ${token}`,
+      ...options.headers,
+    },
+  });
+  if (!res.ok) throw new Error(`GitHub API error: ${res.status}`);
+  return res.json();
+}
+
+export async function searchRepoFiles(query: string, token: string): Promise<string[]> {
+  if (!query) return [];
+  const url = `${API}/search/code?q=${encodeURIComponent(query)}+repo:${OWNER}/${REPO}`;
+  const data = await gh<{ items: { path: string }[] }>(url, token);
+  return data.items.map((i) => i.path);
+}
+
+export async function fetchFileContent(path: string, token: string): Promise<string> {
+  const url = `${API}/repos/${OWNER}/${REPO}/contents/${path}`;
+  const data = await gh<{ content: string }>(url, token);
+  return atob(data.content.replace(/\n/g, ''));
+}
+
+export async function submitDocumentPR(path: string, content: string, token: string): Promise<void> {
+  // Simplified workflow using the contents API
+  const branch = `exegesis-app-${Date.now()}`;
+  const repo = await gh<{ default_branch: string }>(`${API}/repos/${OWNER}/${REPO}`, token);
+  const head = await gh<{ object: { sha: string } }>(
+    `${API}/repos/${OWNER}/${REPO}/git/refs/heads/${repo.default_branch}`,
+    token
+  );
+
+  await gh(
+    `${API}/repos/${OWNER}/${REPO}/git/refs`,
+    token,
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        ref: `refs/heads/${branch}`,
+        sha: head.object.sha,
+      }),
+    }
+  );
+
+  await gh(
+    `${API}/repos/${OWNER}/${REPO}/contents/${path}`,
+    token,
+    {
+      method: 'PUT',
+      body: JSON.stringify({
+        message: `Add ${path}`,
+        content: btoa(content),
+        branch,
+      }),
+    }
+  );
+
+  await gh(
+    `${API}/repos/${OWNER}/${REPO}/pulls`,
+    token,
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        title: `Add ${path}`,
+        head: branch,
+        base: repo.default_branch,
+        body: 'Automated submission from Exegesis App',
+      }),
+    }
+  );
+}


### PR DESCRIPTION
## Summary
- implement GitHub context and login with personal access token
- allow searching repo files and viewing/editing content
- submit new Markdown files or edits via PR through GitHub API
- update README to describe GitHub integration

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683bd14e69e883279ba7f2eed2d9e12a