### PR TITLE
Switch to octokit for GitHub API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2,5 +2,8 @@
   "name": "exegesis_app",
   "lockfileVersion": 3,
   "requires": true,
-  "packages": {}
+  "packages": {},
+  "dependencies": {
+    "octokit": "^2.0.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "octokit": "^2.0.0"
   },
   "devDependencies": {
     "vite": "^5.0.0",

--- a/src/githubApi.ts
+++ b/src/githubApi.ts
@@ -1,78 +1,50 @@
+import { Octokit } from 'octokit';
+
 const OWNER = 'theonize';
 const REPO = 'exegesis';
-const API = 'https://api.github.com';
 
-async function gh<T>(url: string, token: string, options: RequestInit = {}): Promise<T> {
-  const res = await fetch(url, {
-    ...options,
-    headers: {
-      Accept: 'application/vnd.github+json',
-      Authorization: `token ${token}`,
-      ...options.headers,
-    },
-  });
-  if (!res.ok) throw new Error(`GitHub API error: ${res.status}`);
-  return res.json();
+function createOctokit(token: string) {
+  return new Octokit({ auth: token });
 }
 
 export async function searchRepoFiles(query: string, token: string): Promise<string[]> {
   if (!query) return [];
-  const url = `${API}/search/code?q=${encodeURIComponent(query)}+repo:${OWNER}/${REPO}`;
-  const data = await gh<{ items: { path: string }[] }>(url, token);
-  return data.items.map((i) => i.path);
+  const octokit = createOctokit(token);
+  const res = await octokit.rest.search.code({ q: `${query}+repo:${OWNER}/${REPO}` });
+  return res.data.items.map((item) => item.path);
 }
 
 export async function fetchFileContent(path: string, token: string): Promise<string> {
-  const url = `${API}/repos/${OWNER}/${REPO}/contents/${path}`;
-  const data = await gh<{ content: string }>(url, token);
-  return atob(data.content.replace(/\n/g, ''));
+  const octokit = createOctokit(token);
+  const res = await octokit.rest.repos.getContent({ owner: OWNER, repo: REPO, path });
+  if (!('content' in res.data)) throw new Error('Invalid content response');
+  const data = res.data as unknown as { content: string };
+  return Buffer.from(data.content.replace(/\n/g, ''), 'base64').toString('utf8');
 }
 
 export async function submitDocumentPR(path: string, content: string, token: string): Promise<void> {
-  // Simplified workflow using the contents API
+  const octokit = createOctokit(token);
+  const { data: repo } = await octokit.rest.repos.get({ owner: OWNER, repo: REPO });
+  const { data: head } = await octokit.rest.git.getRef({ owner: OWNER, repo: REPO, ref: `heads/${repo.default_branch}` });
+
   const branch = `exegesis-app-${Date.now()}`;
-  const repo = await gh<{ default_branch: string }>(`${API}/repos/${OWNER}/${REPO}`, token);
-  const head = await gh<{ object: { sha: string } }>(
-    `${API}/repos/${OWNER}/${REPO}/git/refs/heads/${repo.default_branch}`,
-    token
-  );
+  await octokit.rest.git.createRef({ owner: OWNER, repo: REPO, ref: `refs/heads/${branch}`, sha: head.object.sha });
 
-  await gh(
-    `${API}/repos/${OWNER}/${REPO}/git/refs`,
-    token,
-    {
-      method: 'POST',
-      body: JSON.stringify({
-        ref: `refs/heads/${branch}`,
-        sha: head.object.sha,
-      }),
-    }
-  );
+  await octokit.rest.repos.createOrUpdateFileContents({
+    owner: OWNER,
+    repo: REPO,
+    path,
+    message: `Add ${path}`,
+    content: Buffer.from(content, 'utf8').toString('base64'),
+    branch,
+  });
 
-  await gh(
-    `${API}/repos/${OWNER}/${REPO}/contents/${path}`,
-    token,
-    {
-      method: 'PUT',
-      body: JSON.stringify({
-        message: `Add ${path}`,
-        content: btoa(content),
-        branch,
-      }),
-    }
-  );
-
-  await gh(
-    `${API}/repos/${OWNER}/${REPO}/pulls`,
-    token,
-    {
-      method: 'POST',
-      body: JSON.stringify({
-        title: `Add ${path}`,
-        head: branch,
-        base: repo.default_branch,
-        body: 'Automated submission from Exegesis App',
-      }),
-    }
-  );
+  await octokit.rest.pulls.create({
+    owner: OWNER,
+    repo: REPO,
+    title: `Add ${path}`,
+    head: branch,
+    base: repo.default_branch,
+    body: 'Automated submission from Exegesis App',
+  });
 }


### PR DESCRIPTION
## Summary
- add `octokit` as a dependency
- rewrite GitHub API helper to use Octokit

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c5430c69483278c39984e7dc79dc0