### PR TITLE
Add OAuth login support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy this file to .env and set your GitHub OAuth app client ID
+VITE_GH_OAUTH_CLIENT_ID=

--- a/README.md
+++ b/README.md
@@ -15,7 +15,17 @@ This project provides a simple Vite + React frontend written in TypeScript using
    npm run dev
    ```
 
-The application now includes minimal GitHub integration. Users provide a
-personal access token to authenticate, search for documents in the
-`theorize/exegesis` repository, view their contents and submit or edit
-markdown files via automatically generated pull requests.
+### Configuration
+
+Create a `.env` file in the project root and set the following environment
+variable pointing to your GitHub OAuth app's client ID:
+
+```bash
+VITE_GH_OAUTH_CLIENT_ID=<your client id>
+```
+
+The application now includes minimal GitHub integration. Users can either
+authenticate with GitHub via OAuth or provide a personal access token. Once
+authenticated they can search for documents in the `theorize/exegesis`
+repository, view their contents and submit or edit markdown files via
+automatically generated pull requests.

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -1,16 +1,45 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useGitHub } from '../GitHubContext';
+import { exchangeCodeForToken } from '../oauth';
 
 export default function Login() {
   const { token, setToken } = useGitHub();
   const [inputToken, setInputToken] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  // handle OAuth callback
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const code = params.get('code');
+    if (code && !token) {
+      setLoading(true);
+      exchangeCodeForToken(code)
+        .then((t) => {
+          setToken(t);
+          params.delete('code');
+          const newUrl = `${window.location.pathname}?${params.toString()}`;
+          window.history.replaceState({}, '', newUrl);
+        })
+        .finally(() => setLoading(false));
+    }
+  }, [token, setToken]);
+
+  const oauthClientId = import.meta.env.VITE_GH_OAUTH_CLIENT_ID;
+  const oauthUrl = `https://github.com/login/oauth/authorize?client_id=${oauthClientId}&scope=repo`;
 
   if (token) return <p>Authenticated with GitHub</p>;
 
   return (
     <div>
       <h2>GitHub Login</h2>
-      <p>Enter a personal access token to authenticate.</p>
+      {loading && <p>Authenticating...</p>}
+      <button onClick={() => (window.location.href = oauthUrl)}>
+        Sign in with GitHub
+      </button>
+      <button disabled style={{ marginLeft: '0.5rem' }}>
+        Sign in with Passkey (coming soon)
+      </button>
+      <p>or enter a personal access token:</p>
       <input
         type="password"
         value={inputToken}

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -1,0 +1,13 @@
+export async function exchangeCodeForToken(code: string): Promise<string> {
+  const res = await fetch(`/api/oauth/github?code=${encodeURIComponent(code)}`, {
+    method: 'POST',
+  });
+  if (!res.ok) {
+    throw new Error('OAuth token exchange failed');
+  }
+  const data = await res.json();
+  if (!data.token) {
+    throw new Error('Missing token in OAuth response');
+  }
+  return data.token as string;
+}


### PR DESCRIPTION
## Summary
- support GitHub OAuth sign-in
- keep PAT login as a fallback
- show placeholder button for passkey
- add oauth token exchange helper and example `.env` file
- document OAuth setup in README

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c5458b7ec83279d982e6c19396507