### PR TITLE
Allow repo search without login

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ VITE_GH_OAUTH_CLIENT_ID=<your client id>
 ```
 
 The application now includes minimal GitHub integration. Users can either
-authenticate with GitHub via OAuth or provide a personal access token. Once
-authenticated they can search for documents in the `theorize/exegesis`
-repository, view their contents and submit or edit markdown files via
+authenticate with GitHub via OAuth or provide a personal access token.
+
+Unauthenticated users are still able to search the public repository and view
+documents. Authentication is only required when submitting or editing files via
 automatically generated pull requests.

--- a/src/components/DocumentViewer.tsx
+++ b/src/components/DocumentViewer.tsx
@@ -10,7 +10,6 @@ export default function DocumentViewer({ path }: { path: string }) {
 
   useEffect(() => {
     async function load() {
-      if (!token) return;
       const c = await fetchFileContent(path, token);
       setContent(c);
       setEditText(c);

--- a/src/components/RepoSearch.tsx
+++ b/src/components/RepoSearch.tsx
@@ -10,7 +10,6 @@ export default function RepoSearch() {
   const [selected, setSelected] = useState<string | null>(null);
 
   async function handleSearch() {
-    if (!token) return;
     const files = await searchRepoFiles(query, token);
     setResults(files);
   }
@@ -19,7 +18,7 @@ export default function RepoSearch() {
     <div>
       <h2>Search Documents</h2>
       <input value={query} onChange={(e) => setQuery(e.target.value)} />
-      <button onClick={handleSearch} disabled={!token}>Search</button>
+      <button onClick={handleSearch}>Search</button>
       <ul>
         {results.map((path) => (
           <li key={path}>

--- a/src/githubApi.ts
+++ b/src/githubApi.ts
@@ -3,18 +3,18 @@ import { Octokit } from 'octokit';
 const OWNER = 'theonize';
 const REPO = 'exegesis';
 
-function createOctokit(token: string) {
-  return new Octokit({ auth: token });
+function createOctokit(token?: string | null) {
+  return token ? new Octokit({ auth: token }) : new Octokit();
 }
 
-export async function searchRepoFiles(query: string, token: string): Promise<string[]> {
+export async function searchRepoFiles(query: string, token?: string | null): Promise<string[]> {
   if (!query) return [];
   const octokit = createOctokit(token);
   const res = await octokit.rest.search.code({ q: `${query}+repo:${OWNER}/${REPO}` });
   return res.data.items.map((item) => item.path);
 }
 
-export async function fetchFileContent(path: string, token: string): Promise<string> {
+export async function fetchFileContent(path: string, token?: string | null): Promise<string> {
   const octokit = createOctokit(token);
   const res = await octokit.rest.repos.getContent({ owner: OWNER, repo: REPO, path });
   if (!('content' in res.data)) throw new Error('Invalid content response');


### PR DESCRIPTION
## Summary
- allow Github API calls without a token
- remove token checks on search and view operations
- document that login is only required for edits/PRs

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ca1ac70848327b28e78800ee73557