### PR TITLE
Fix Octokit browser build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,4 +3,7 @@ import react from '@vitejs/plugin-react-swc';
 
 export default defineConfig({
   plugins: [react()],
+  define: {
+    global: 'window',
+  },
 });


### PR DESCRIPTION
## Summary
- define `global` as `window` during Vite build so Octokit works in the browser

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cb2135de083278c0646901831dd8b